### PR TITLE
Comma separate minified array items

### DIFF
--- a/json.rb
+++ b/json.rb
@@ -55,7 +55,7 @@ module LevisLibs
         values = self.map { |v| "#{v.to_json(indent_depth: indent_depth + 1, indent_size: indent_size, minify: minify, space_in_empty: space_in_empty)}" }
 
         if minify
-          "[#{values.join("")}]"
+          "[#{values.join(",")}]"
         else
           indent = " " * (indent_depth * indent_size)
           indent_p1 = " " * ((indent_depth + 1) * indent_size)


### PR DESCRIPTION
Currently a minified array will be output as

```
{"version":"0.14.3","members":[{"name":"Uttra","level":1,"cclass":"Knight"}{"name":"Cathal","level":1,"cclass":"Cleric"}{"name":"Gerard","level":1,"cclass":"Hunter"}{"name":"Aife","level":1,"cclass":"Mage"}],"silver":2000}
```

This is not valid JSON due to missing commas betwixt array items:

```
Error: Parse error on line 1:
...1,"cclass":"Knight"}{"name":"Cathal","le
-----------------------^
Expecting 'EOF', '}', ',', ']', got '{'
```