### PR TITLE
Serialize/Deserialize Symbol values

### DIFF
--- a/json.rb
+++ b/json.rb
@@ -323,14 +323,15 @@ module LevisLibs
         indent_depth: 0,
         indent_size: 4,
         minify: false,
-        space_in_empty: true
+        space_in_empty: true,
+        hash_key: false
       )
         raise JSONKeyError, "Not all keys are instances of `String` or `Symbol`" if !keys.all? { String === _1 || Symbol === _1 }
 
         return "{#{space_in_empty && !minify ? " " : ""}}" if self.length == 0
 
         space = minify ? "" : " "
-        pairs = self.map { |k, v| "#{k.to_json}:#{space}#{v.to_json(indent_depth: indent_depth + 1, indent_size: indent_size, minify: minify, space_in_empty: space_in_empty)}" }
+        pairs = self.map { |k, v| "#{k.to_json(hash_key: true)}:#{space}#{v.to_json(indent_depth: indent_depth + 1, indent_size: indent_size, minify: minify, space_in_empty: space_in_empty)}" }
 
         if minify
           "{#{pairs.join(",")}}"
@@ -373,7 +374,8 @@ module LevisLibs
         indent_depth: 0,
         indent_size: 4,
         minify: false,
-        space_in_empty: true
+        space_in_empty: true,
+        hash_key: false
       )
         self.inspect
       end
@@ -384,7 +386,8 @@ module LevisLibs
         indent_depth: 0,
         indent_size: 4,
         minify: false,
-        space_in_empty: true
+        space_in_empty: true,
+        hash_key: false
       )
         "true"
       end
@@ -395,7 +398,8 @@ module LevisLibs
         indent_depth: 0,
         indent_size: 4,
         minify: false,
-        space_in_empty: true
+        space_in_empty: true,
+        hash_key: false
       )
         "false"
       end
@@ -406,7 +410,8 @@ module LevisLibs
         indent_depth: 0,
         indent_size: 4,
         minify: false,
-        space_in_empty: true
+        space_in_empty: true,
+        hash_key: false
       )
         "null"
       end
@@ -417,7 +422,8 @@ module LevisLibs
         indent_depth: 0,
         indent_size: 4,
         minify: false,
-        space_in_empty: true
+        space_in_empty: true,
+        hash_key: false
       )
         self.inspect
       end
@@ -428,7 +434,8 @@ module LevisLibs
         indent_depth: 0,
         indent_size: 4,
         minify: false,
-        space_in_empty: true
+        space_in_empty: true,
+        hash_key: false
       )
         self.to_s.inspect
       end
@@ -439,7 +446,8 @@ module LevisLibs
         indent_depth: 0,
         indent_size: 4,
         minify: false,
-        space_in_empty: true
+        space_in_empty: true,
+        hash_key: false
       )
         raise JSONUnsupportedType, "Object of class #{self.class.name} cannot be serialized to JSON"
       end

--- a/json.rb
+++ b/json.rb
@@ -106,6 +106,7 @@ module LevisLibs
 
           hsh = __parse_members(**kw)
           __expect!("}")
+          hsh = __parse_symbol_value_if_needed(hsh, **kw)
           hsh
         when "["
           __advance
@@ -291,6 +292,13 @@ module LevisLibs
         (value = __parse_element(**kw))
         [kw[:symbolize_keys] ? key.to_sym : key, value]
       end
+
+      def __parse_symbol_value_if_needed(hsh, **kw)
+        special_symbol_key = kw[:symbolize_keys] ? :__symbol__ : '__symbol__'
+        return hsh[special_symbol_key].to_sym if hsh.keys == [special_symbol_key]
+
+        hsh
+      end
     end
 
     class JSONKeyError < StandardError
@@ -437,7 +445,16 @@ module LevisLibs
         space_in_empty: true,
         hash_key: false
       )
-        self.to_s.inspect
+        if hash_key
+          self.to_s.inspect
+        else
+          { __symbol__: self.to_s }.to_json(
+            indent_depth: indent_depth,
+            indent_size: indent_size,
+            minify: minify,
+            space_in_empty: space_in_empty
+          )
+        end
       end
     end
 


### PR DESCRIPTION
My approach to encoding/decoding Symbol values consists of two parts

1) Add an optional `hash_key` keyword argument to the `to_json` method to be able to distinguish between symbol keys and values
2) Encode Symbol values as a special hash
  ```rb
  :a_symbol
  ``` 
  will become 
  ```json
  {"__symbol__": "a_symbol"}
  ```
  
Not sure if you like this approach ;) but it's one possibility!